### PR TITLE
feat: modern redesign with new primary palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,34 +4,49 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Aakrati — Interior Design Artist</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Poppins:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <header class="site-header">
-    <img src="logo.png" alt="Aakrati Logo" class="logo" />
-    <nav>
+    <a href="#" class="brand"
+      ><img src="public/assets/logo.png" alt="Aakrati Logo" class="logo"
+    /></a>
+    <button class="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
+    <nav class="site-nav">
       <ul>
-        <li><a href="#">Home</a></li>
-        <li><a href="#">Projects</a></li>
-        <li><a href="#">Services</a></li>
+        <li><a href="#hero">Home</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#services">Services</a></li>
         <li><a href="#">Contact</a></li>
       </ul>
     </nav>
   </header>
 
-  <section class="hero">
-    <h1>Creating Unique, Functional & Elegant Spaces</h1>
-    <p>Interior Design crafted with attention to detail, creativity, and purpose.</p>
+  <section id="hero" class="hero">
+    <div class="hero-content">
+      <h1>Creating Unique, Functional & Elegant Spaces</h1>
+      <p>
+        Interior Design crafted with attention to detail, creativity, and purpose.
+      </p>
+    </div>
   </section>
 
-  <section class="about">
+  <section id="about" class="about">
     <h2>About Aakrati</h2>
-    <p>“Creator of ideas, swimming in the sparkling sea of imagination.”<br/>
-    We understand that every client is unique. Our philosophy is detail-driven,
-    blending aesthetics with functionality.</p>
+    <p>
+      “Creator of ideas, swimming in the sparkling sea of imagination.”<br />
+      We understand that every client is unique. Our philosophy is detail-driven,
+      blending aesthetics with functionality.
+    </p>
   </section>
 
-  <section class="services">
+  <section id="services" class="services">
     <h2>Our Services</h2>
     <div class="service-grid">
       <div class="service">Turn Key Solutions</div>
@@ -46,5 +61,11 @@
   <footer class="site-footer">
     <p>&copy; 2025 Aakrati Interior Design Artist. All Rights Reserved.</p>
   </footer>
+
+  <script>
+    const toggle = document.querySelector('.menu-toggle');
+    const nav = document.querySelector('.site-nav');
+    toggle.addEventListener('click', () => nav.classList.toggle('open'));
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,72 +1,161 @@
+/* Color palette derived from provided logo */
 :root {
-  --primary: #e27d87; /* from logo bg */
-  --secondary: #d9e0e2; /* from visiting card light bg */
-  --text: #222222;
+  --primary: #e27d87;
+  --secondary: #d9e0e2;
+  --dark: #1a1a1a;
+  --light: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  font-family: 'Helvetica Neue', sans-serif;
-  color: var(--text);
+  font-family: 'Poppins', sans-serif;
+  color: var(--dark);
   background: var(--secondary);
+  line-height: 1.6;
 }
 
 .site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 1rem 2rem;
-  background: var(--primary);
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--light);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .logo {
-  height: 50px;
+  height: 48px;
 }
 
-nav ul {
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.site-nav ul {
   list-style: none;
   display: flex;
-  gap: 1rem;
+  gap: 1.5rem;
   margin: 0;
   padding: 0;
 }
 
-nav a {
-  color: white;
+.site-nav a {
   text-decoration: none;
-  font-weight: bold;
+  color: var(--dark);
+  font-weight: 600;
 }
 
 .hero {
-  background: white;
+  position: relative;
+  background: url('public/assets/brand-hero.jpg') center/cover no-repeat;
+  color: var(--light);
+  min-height: 70vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  padding: 4rem 2rem;
+  padding: 2rem;
 }
 
-.about, .services {
-  padding: 2rem;
-  background: white;
-  margin: 1rem auto;
-  max-width: 900px;
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 700px;
+}
+
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.1rem;
+}
+
+.about,
+.services {
+  max-width: 1000px;
+  margin: 4rem auto;
+  padding: 0 1rem;
+  text-align: center;
+}
+
+.about h2,
+.services h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2rem;
+  color: var(--primary);
+  margin-bottom: 1rem;
 }
 
 .service-grid {
+  margin-top: 2rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
 }
 
 .service {
-  background: var(--secondary);
-  padding: 1rem;
-  border-radius: 8px;
-  text-align: center;
+  background: var(--light);
+  padding: 2rem 1rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
+  transition: transform 0.3s ease;
+}
+
+.service:hover {
+  transform: translateY(-4px);
 }
 
 .site-footer {
   text-align: center;
-  padding: 1rem;
+  padding: 2rem 1rem;
   background: var(--primary);
-  color: white;
+  color: var(--light);
+}
+
+@media (max-width: 768px) {
+  .menu-toggle {
+    display: block;
+  }
+
+  .site-nav {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--light);
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    padding: 1rem 0;
+  }
+
+  .site-nav.open {
+    display: flex;
+  }
+
+  .site-nav ul {
+    flex-direction: column;
+    gap: 1rem;
+  }
 }


### PR DESCRIPTION
## Summary
- revamp landing page with responsive navigation and hero
- apply primary colour and typography from brand palette
- streamline assets and remove empty logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbd5df3cc832f84e3b10356c543b0