### PR TITLE
fix: deploy GitHub Pages from public directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
-          path: .
+          path: ./public
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- serve static site by uploading `public` folder to GitHub Pages
- keep artifact upload path simple to avoid duplicate key errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acebfd09f0832f8f204bff9c564478