### PR TITLE
fix: deploy docs to pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
-          path: ${{ github.workspace }}/public
-          path: ./public
+          path: ./docs
   deploy:
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- point GitHub Pages workflow to `docs` directory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acf1023410832f96a47e727c8907e4